### PR TITLE
fix: use linker flag headerpad_max_install_names for osx, latest ldc

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ MTRIPLE=""
 if [[ "$target_platform" == "osx-arm64" ]]; then
     # Get the arm64 lib files
     # Ideally, we would get these from the conda-forge ldc2 arm64 package, but it is not available yet
-    LDC_VERSION=1.38.0
+    LDC_VERSION=1.39.0
     LDC_ARCH=osx-arm64
     wget https://github.com/ldc-developers/ldc/releases/download/v$LDC_VERSION/ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz
     tar -xf ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,7 @@ fi
 if [[ "$target_platform" == "osx-arm64" ]]; then
     # Get the arm64 lib files
     # Ideally, we would get these from the conda-forge ldc2 arm64 package, but it is not available yet
-    latest_version=$(curl -s https://api.github.com/repos/ldc-developer/ldc/releases/latest | jq -r .tag_name | sed 's/^v//')
+    latest_version=$(curl -s https://api.github.com/repos/ldc-developers/ldc/releases/latest | jq -r .tag_name | sed 's/^v//')
     LDC_VERSION=latest_version
     LDC_ARCH=osx-arm64
     wget https://github.com/ldc-developers/ldc/releases/download/v$LDC_VERSION/ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,13 @@
 set -euxo pipefail
 
 MTRIPLE=""
+OSX_FLAGS=""
+
+# if target platform starts with osx
+if [[ "$target_platform" == osx-* ]]; then
+    MTRIPLE="-mtriple=x86_64-apple-macosx10.9"
+    OSX_FLAGS="-Wl,-headerpad_max_install_names"
+fi
 
 if [[ "$target_platform" == "osx-arm64" ]]; then
     # Get the arm64 lib files
@@ -36,6 +43,6 @@ EOF
 
 fi
 
-make DCOMPILER=ldc2 DFLAGS="-link-defaultlib-shared=false $MTRIPLE"
+make DCOMPILER=ldc2 DFLAGS="-link-defaultlib-shared=false $MTRIPLE $OSX_FLAGS"
 
 cp -r bin "$PREFIX"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,8 @@ MTRIPLE=""
 if [[ "$target_platform" == "osx-arm64" ]]; then
     # Get the arm64 lib files
     # Ideally, we would get these from the conda-forge ldc2 arm64 package, but it is not available yet
-    LDC_VERSION=1.39.0
+    latest_version=$(curl -s https://api.github.com/repos/ldc-developer/ldc/releases/latest | jq -r .tag_name | sed 's/^v//')
+    LDC_VERSION=latest_version
     LDC_ARCH=osx-arm64
     wget https://github.com/ldc-developers/ldc/releases/download/v$LDC_VERSION/ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz
     tar -xf ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ OSX_FLAGS=""
 # if target platform starts with osx
 if [[ "$target_platform" == osx-* ]]; then
     MTRIPLE="-mtriple=x86_64-apple-macosx10.9"
-    OSX_FLAGS="-Wl,-headerpad_max_install_names"
+    OSX_FLAGS="-L-Wl,-headerpad_max_install_names"
 fi
 
 if [[ "$target_platform" == "osx-arm64" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ OSX_FLAGS=""
 
 # if target platform starts with osx
 if [[ "$target_platform" == osx-* ]]; then
-    MTRIPLE="-mtriple=x86_64-apple-macosx10.9"
+    MTRIPLE="-mtriple=x86_64-apple-macosx10.13"
     OSX_FLAGS="-L-Wl,-headerpad_max_install_names"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,7 @@ if [[ "$target_platform" == "osx-arm64" ]]; then
     # Get the arm64 lib files
     # Ideally, we would get these from the conda-forge ldc2 arm64 package, but it is not available yet
     latest_version=$(curl -s https://api.github.com/repos/ldc-developers/ldc/releases/latest | jq -r .tag_name | sed 's/^v//')
-    LDC_VERSION=latest_version
+    LDC_VERSION=$latest_version
     LDC_ARCH=osx-arm64
     wget https://github.com/ldc-developers/ldc/releases/download/v$LDC_VERSION/ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz
     tar -xf ldc2-$LDC_VERSION-$LDC_ARCH.tar.xz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 7
   skip: true  # [win]
+  ignore_run_exports:
+    - ldc
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 07c8a62962f9bb624f402281ccb3c571509d4bc48f8fdc5a1d056775bc764e9a
 
 build:
-  number: 6
+  number: 7
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
